### PR TITLE
Define `OPENBSD_TRUSTED_MIRROR` and `OPENBSD_MIRROR` later

### DIFF
--- a/build_openbsd_qcow2.sh
+++ b/build_openbsd_qcow2.sh
@@ -34,8 +34,10 @@ PATH_TFTP="${TOP_DIR}/tftp"
 OPENBSD_VERSION="7.5"
 OPENBSD_ARCH=amd64
 
-OPENBSD_TRUSTED_MIRROR="https://ftp.openbsd.org/pub/OpenBSD/${OPENBSD_VERSION}"
-OPENBSD_MIRROR="https://cdn.openbsd.org/pub/OpenBSD/${OPENBSD_VERSION}"
+OPENBSD_TRUSTED_MIRROR_BASE="https://ftp.openbsd.org/pub/OpenBSD"
+OPENBSD_MIRROR_BASE="https://cdn.openbsd.org/pub/OpenBSD"
+OPENBSD_TRUSTED_MIRROR=""
+OPENBSD_MIRROR=""
 
 IMAGE_SIZE=20
 IMAGE_NAME="${PATH_IMAGES}/openbsd${v}_$(date +%Y-%m-%d).qcow2"
@@ -270,6 +272,8 @@ if [[ -z "$RUN" ]]; then
 else
     v=${OPENBSD_VERSION//./}
     SETS="${SETS} site${v}.tgz"
+    OPENBSD_MIRROR="${OPENBSD_MIRROR_BASE}/${OPENBSD_VERSION}"
+    OPENBSD_TRUSTED_MIRROR="${OPENBSD_TRUSTED_MIRROR_BASE}/${OPENBSD_VERSION}"
 
     report "[1/7] Check for dependencies"
     check_for_programs


### PR DESCRIPTION
Currently, if a user sets a different version of OpenBSD to fetch, then this script will fetch 7.5 anyway, since the mirror URLs are defined up top, before `OPENBSD_VERSION` is set  to the value that the user requested.

This diff sets the base of these URLs up top, then defines the full URL once we know what version the user is requesting.