### PR TITLE
create the partitions after the first boot

### DIFF
--- a/build_openbsd_qcow2.sh
+++ b/build_openbsd_qcow2.sh
@@ -39,7 +39,7 @@ OPENBSD_MIRROR_BASE="https://cdn.openbsd.org/pub/OpenBSD"
 OPENBSD_TRUSTED_MIRROR=""
 OPENBSD_MIRROR=""
 
-IMAGE_SIZE=20
+IMAGE_SIZE=8
 IMAGE_NAME="${PATH_IMAGES}/openbsd${v}_$(date +%Y-%m-%d).qcow2"
 
 QEMU_CPUS=2

--- a/custom/disklabel
+++ b/custom/disklabel
@@ -1,10 +1,2 @@
-/           150M-1G
+/           3G
 swap        80M-256M 10%
-/usr        1.5G-30G 5%
-/tmp        120M-4G  8%
-/var        80M-4G   13%
-/usr/X11R6  384M-1G  3%
-/usr/local  1G-20G   10%
-/usr/src    2G-5G    2%
-/usr/obj    5G-6G    4%
-/home       1G-*     45%

--- a/custom/resize_partitions.sh
+++ b/custom/resize_partitions.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+function add_part {
+path=$1
+size=$2
+
+echo "Adding ${path} (size=$2)"
+echo "a\n\n\n${size}\n\n${path}\nw\n"| disklabel -f /etc/fstab -E sd0
+mkdir -p ${path}
+new_dev=$(cat /etc/fstab |grep " ${path} "|cut -d " " -f 1|sed 's,/dev/,,')
+newfs ${new_dev}
+if [ -d ${path} ]; then
+mv ${path} ${path}.orig
+mkdir -p ${path}
+mount ${path}
+cp -Rp  ${path}.orig/* ${path}
+rm -r ${path}.orig
+fi
+}
+
+
+add_part /tmp 1000000
+add_part /var 400000
+add_part /usr 6000000
+add_part /usr/X11R6 600000
+add_part /usr/local 6000000
+add_part /usr/src 600000
+add_part /usr/obj 600000
+add_part /home    *


### PR DESCRIPTION
Boot with only a sawp and / partitions. The rest is created by the user after the first boot.

The idea is to boot a minimalist system with everything in the / partition and let the users decided the setup they want.