### PR TITLE
reduce the size of the base system

### DIFF
--- a/build_openbsd_qcow2.sh
+++ b/build_openbsd_qcow2.sh
@@ -39,7 +39,7 @@ OPENBSD_MIRROR_BASE="https://cdn.openbsd.org/pub/OpenBSD"
 OPENBSD_TRUSTED_MIRROR=""
 OPENBSD_MIRROR=""
 
-IMAGE_SIZE=20
+IMAGE_SIZE=2
 IMAGE_NAME="${PATH_IMAGES}/openbsd${v}_$(date +%Y-%m-%d).qcow2"
 
 QEMU_CPUS=2
@@ -98,7 +98,7 @@ function check_for_programs {
 }
 
 function build_mirror {
-    files="base${v}.tgz bsd bsd.mp bsd.rd comp${v}.tgz game${v}.tgz man${v}.tgz pxeboot xbase${v}.tgz xfont${v}.tgz xserv${v}.tgz xshare${v}.tgz"
+    files="base${v}.tgz bsd bsd.mp bsd.rd comp${v}.tgz man${v}.tgz pxeboot"
 
     exec_cmd curl --fail -C - -O --create-dirs --output-dir "${PATH_MIRROR}/pub/OpenBSD/${OPENBSD_VERSION}" "${OPENBSD_TRUSTED_MIRROR}/openbsd-${v}-base.pub"
 
@@ -108,7 +108,7 @@ function build_mirror {
     done
 
     exec_cmd cd "${TOP_DIR}/custom"
-    exec_cmd tar -czf "${PATH_MIRROR}/pub/OpenBSD/${OPENBSD_VERSION}/amd64/site${v}.tgz" install.site
+    exec_cmd tar -czf "${PATH_MIRROR}/pub/OpenBSD/${OPENBSD_VERSION}/amd64/site${v}.tgz" install.site create_partitions.sh
 
     exec_cmd cd "${PATH_MIRROR}/pub/OpenBSD/${OPENBSD_VERSION}/${OPENBSD_ARCH}"
     exec_cmd ls -l | tail -n +2 | exec_cmd tee index.txt

--- a/custom/create_partitions.sh
+++ b/custom/create_partitions.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env sh
+
+function stop_services {
+/etc/rc.d/sndiod stop
+/etc/rc.d/ntpd stop
+/etc/rc.d/smtpd stop
+/etc/rc.d/cron stop
+}
+
+function start_services {
+/etc/rc.d/sndiod start
+/etc/rc.d/ntpd start
+/etc/rc.d/smtpd start
+/etc/rc.d/cron start
+}
+
+function add_swap {
+size=$1
+
+echo "Adding swap (size=${size})"
+echo "b\n\n*\na\n\n\n${size}\n\n\nw\n"| disklabel -v -f /etc/fstab -E sd0
+
+}
+
+function add_part {
+path=$1
+size=$2
+
+echo "Adding ${path} (size=${size})"
+echo "b\n\n*\na\n\n\n${size}\n\n${path}\nw\n"| disklabel -v -f /etc/fstab -E sd0
+mkdir -p ${path}
+new_dev=$(grep " ${path} " /etc/fstab|cut -d " " -f 1|sed 's,/dev/,,')
+newfs ${new_dev}
+if [ -d ${path} ]; then
+mv ${path} ${path}.orig
+mkdir -p ${path}
+mount ${path}
+cp -Rp  ${path}.orig/* ${path}
+rm -r ${path}.orig
+fi
+}
+
+add_swap 400m
+add_part /tmp 1000m
+add_part /var 4000m
+add_part /usr 5000m
+add_part /usr/local 6000m
+add_part /usr/src 2000m
+add_part /usr/obj 2000m
+add_part /home    '*'
+
+

--- a/custom/disklabel
+++ b/custom/disklabel
@@ -1,10 +1,1 @@
-/           150M-1G
-swap        80M-256M 10%
-/usr        1.5G-30G 5%
-/tmp        120M-4G  8%
-/var        80M-4G   13%
-/usr/X11R6  384M-1G  3%
-/usr/local  1G-20G   10%
-/usr/src    2G-5G    2%
-/usr/obj    5G-6G    4%
-/home       1G-*     45%
+/           *

--- a/custom/install.conf
+++ b/custom/install.conf
@@ -1,6 +1,6 @@
 System hostname = openbsd
 Password for root = *************
-Allow root ssh login = yes
+Allow root ssh login = no
 Change the default console to com0 = yes
 Which speed should com0 use = 115200
 Setup a user = no
@@ -11,3 +11,4 @@ Do you expect to run the X Window System = no
 Checksum test for site75.tgz failed. Continue anyway = yes
 Unverified sets: site75.tgz. Continue without verification = yes
 Cannot determine prefetch area. Continue without verification? = yes
+Set name(s) = -all bsd* base* etc* man* site* comp*

--- a/custom/install.site
+++ b/custom/install.site
@@ -52,3 +52,7 @@ sed -i '/ds-identify/d' /etc/rc.local
 
 # Clean-up the network config
 rm -f /etc/resolv.conf /etc/hostname.*
+
+echo "\n\nThe cloud-image comes with a minimalist / partition. You can use the remaining disk space by adjusting /create_partitions.sh to match your expectation and run the script as root."  >> /etc/motd
+
+rm /install.site


### PR DESCRIPTION
Boot with a small / partition. The free disk space can be allocated by the user
using the /create_partitions.sh script.

This allow us to give the choice to the users of how they want to prepare the
disk partitions.
