### PR TITLE
fix: patch cloud.cfg after build-on-openbsd for OpenBSD compatibility

### DIFF
--- a/custom/install.site
+++ b/custom/install.site
@@ -53,6 +53,18 @@ fi
 ./tools/build-on-openbsd
 
 ###########
+# Patching cloud-init generated config
+###########
+
+# Fix: update_etc_hosts requires hosts.openbsd.tmpl which is absent on OpenBSD
+# causing a permanent status:failed at every boot
+sed -i 's/^  - update_etc_hosts/  # - update_etc_hosts/' /etc/cloud/cloud.cfg
+
+# Fix: sudo entry generated unconditionally for all variants including OpenBSD
+# where sudo is not the standard privilege escalation tool
+sed -i '/    sudo: \[\"ALL=(ALL) NOPASSWD:ALL\"\]/d' /etc/cloud/cloud.cfg
+
+###########
 # Clean-up
 ###########
 


### PR DESCRIPTION
## Problem

Two issues in cloud-init 25.2 `cloud.cfg.tmpl` affect OpenBSD images:

1. `update_etc_hosts` module is included unconditionally for all variants
   but `hosts.openbsd.tmpl` is absent for OpenBSD, causing a `status:failed` on first boot.

2. `sudo` entry is generated for all variants including
   OpenBSD where `doas` is the standard privilege escalation tool.
   The `doas` entry is already correctly generated, making the `sudo`
   entry redundant and inconsistent.

## Fix

Patch `/etc/cloud/cloud.cfg` after `build-on-openbsd` with two `sed`
commands to disable `update_etc_hosts` and remove the `sudo` entry.

## Tested

Verified on OpenBSD 7.8 qcow2 image built with cloud-init 25.2 that:
- `update_etc_hosts` is commented out in the generated `cloud.cfg`
- no `sudo` entry remains in `system_info.default_user`